### PR TITLE
Update install.rdf to enable e10s/multipropcess mode

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -26,6 +26,7 @@
     <em:creator>Steven Tine</em:creator>
     <em:homepageURL>http://cookieSwap.mozdev.org</em:homepageURL>
     <em:iconURL>chrome://cookieswap/skin/CookieSwap.png</em:iconURL>
+    <em:multiprocessCompatible>true</em:multiprocessCompatible> 
   </Description>      
 </RDF>
 


### PR DESCRIPTION
Added the line
em:multiprocessCompatibletrue</em:multiprocessCompatible>
to install.rdf so that firefox will recognize that CookieSwap (cookieswap-firefox) is compatible with the "e10s" multiprocess mode of firefox.

I have tested the mod on a private copy of the source that I extracted from xpi file. Then I discovered that CookieSwap actually lives on github, and decided to submit the mod here.

Suggestion: Please update the cookieswap homepage on AOM (addons.moziulla.org) so that it points to github. It's a great addon and I would hate to see it not getting the exposure and community that it deserves.